### PR TITLE
Improve WhatsApp setup guidance and add QR image/HTML endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Servidor Node + WhatsApp
+
+Este projeto expõe uma API simples em Express, com acesso ao MySQL e integração com o WhatsApp (via `whatsapp-web.js`) para automação de mensagens.
+
+## Pré-requisitos
+
+- Node.js instalado (versão LTS recomendada).
+- Google Chrome/Chromium instalado no servidor (obrigatório para o `whatsapp-web.js`).
+- MySQL disponível conforme configuração em `server.js`.
+
+## Como rodar
+
+1. Instale as dependências:
+   ```bash
+   npm install
+   ```
+
+2. (Opcional) Informe o caminho do Chrome/Chromium via variável de ambiente:
+   ```bash
+   export PUPPETEER_EXECUTABLE_PATH="/usr/bin/google-chrome"
+   ```
+
+3. Suba a API:
+   ```bash
+   npm start
+   ```
+
+## Fluxo de autenticação do WhatsApp
+
+1. Abra o QR para autenticar:
+   - `GET /whatsapp/qr-page` (página HTML com o QR)
+   - `GET /whatsapp/qr` (retorna o QR em base64)
+   - `GET /whatsapp/qr/image` (retorna o PNG)
+
+2. Verifique o status:
+   - `GET /whatsapp/status`
+
+Quando o status for `ready`, já é possível enviar mensagens.
+
+## Enviar mensagem
+
+`POST /whatsapp/send`
+
+Body JSON:
+```json
+{
+  "to": "5511999999999",
+  "message": "Olá! Mensagem automática."
+}
+```
+
+Observação: o campo `to` pode ser o número puro ou com sufixo `@c.us`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
@@ -13,6 +14,8 @@
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "http": "0.0.0",
-    "mysql": "^2.18.0"
+    "mysql": "^2.18.0",
+    "qrcode": "^1.5.4",
+    "whatsapp-web.js": "^1.24.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,12 +5,69 @@ const http = require('http');
 const express = require('express');
 const mysql = require('mysql');
 const bodyParser = require('body-parser');
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcode = require('qrcode');
 
 const router = express.Router();
 const app = express();
 
 const port = 7000;
 app.set('port', port);
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+let latestQr = null;
+let latestQrAt = null;
+let whatsappStatus = 'initializing';
+let whatsappReady = false;
+
+const whatsappPuppeteerOptions = {
+  headless: true,
+  args: ['--no-sandbox', '--disable-setuid-sandbox']
+};
+
+if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+  whatsappPuppeteerOptions.executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+}
+
+const whatsappClient = new Client({
+  authStrategy: new LocalAuth(),
+  puppeteer: whatsappPuppeteerOptions
+});
+
+whatsappClient.on('qr', async (qr) => {
+  latestQr = await qrcode.toDataURL(qr);
+  latestQrAt = new Date().toISOString();
+  whatsappStatus = 'qr';
+  whatsappReady = false;
+});
+
+whatsappClient.on('ready', () => {
+  latestQr = null;
+  latestQrAt = null;
+  whatsappStatus = 'ready';
+  whatsappReady = true;
+});
+
+whatsappClient.on('auth_failure', () => {
+  whatsappStatus = 'auth_failure';
+  whatsappReady = false;
+});
+
+whatsappClient.on('disconnected', () => {
+  whatsappStatus = 'disconnected';
+  whatsappReady = false;
+});
+
+whatsappClient.initialize();
+
+function formatWhatsappId(rawValue) {
+  if (!rawValue) return null;
+  if (rawValue.includes('@c.us') || rawValue.includes('@g.us')) return rawValue;
+  const digits = rawValue.replace(/\D/g, '');
+  if (!digits) return null;
+  return `${digits}@c.us`;
+}
 
 // SELECIONAR TODOS OS USUARIOS DO BANCO CADASTRADOS
 router.get('/users',(req,res,rows)=>{
@@ -30,6 +87,86 @@ router.get('/users/pesquisa/:name?',(req, res) => {
     if(req.params.name) filter = (req.params.name);
     execSqlQuery(`SELECT * FROM  usuarios where nome LIKE "${filter}%";`, res);
     
+});
+
+router.get('/whatsapp/status', (req, res) => {
+  res.json({
+    status: whatsappStatus,
+    ready: whatsappReady,
+    qrAvailable: Boolean(latestQr),
+    qrGeneratedAt: latestQrAt
+  });
+});
+
+router.get('/whatsapp/qr', (req, res) => {
+  if (!latestQr) {
+    res.status(404).json({ message: 'QR code indisponível no momento.' });
+    return;
+  }
+
+  res.json({
+    qr: latestQr,
+    generatedAt: latestQrAt
+  });
+});
+
+router.get('/whatsapp/qr/image', (req, res) => {
+  if (!latestQr) {
+    res.status(404).json({ message: 'QR code indisponível no momento.' });
+    return;
+  }
+
+  const base64Data = latestQr.replace(/^data:image\/png;base64,/, '');
+  const imageBuffer = Buffer.from(base64Data, 'base64');
+  res.setHeader('Content-Type', 'image/png');
+  res.send(imageBuffer);
+});
+
+router.get('/whatsapp/qr-page', (req, res) => {
+  if (!latestQr) {
+    res.status(404).send('<h1>QR code indisponível no momento.</h1>');
+    return;
+  }
+
+  res.send(`
+    <html lang="pt-BR">
+      <head>
+        <meta charset="utf-8" />
+        <title>WhatsApp QR</title>
+      </head>
+      <body style="font-family: Arial, sans-serif; text-align: center; padding-top: 40px;">
+        <h1>Escaneie o QR Code</h1>
+        <img src="${latestQr}" alt="QR Code do WhatsApp" style="max-width: 320px;" />
+        <p>Atualizado em: ${latestQrAt || '-'}</p>
+      </body>
+    </html>
+  `);
+});
+
+router.post('/whatsapp/send', async (req, res) => {
+  if (!whatsappReady) {
+    res.status(409).json({ message: 'WhatsApp não está pronto. Escaneie o QR code primeiro.' });
+    return;
+  }
+
+  const destination = formatWhatsappId(req.body.to);
+  const message = req.body.message;
+
+  if (!destination || !message) {
+    res.status(400).json({ message: 'Informe "to" e "message" no corpo da requisição.' });
+    return;
+  }
+
+  try {
+    const response = await whatsappClient.sendMessage(destination, message);
+    res.json({
+      id: response.id.id,
+      to: destination,
+      status: 'sent'
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Falha ao enviar mensagem.', error: error.message });
+  }
 });
 
 const server = http.createServer(app);


### PR DESCRIPTION
### Motivation
- Make the WhatsApp integration easier to run and debug by documenting steps and adding convenient QR access endpoints. 
- Support environments where Chrome/Chromium is in a non-standard location by allowing a configurable Puppeteer executable path. 
- Provide a simple HTTP API to check auth status and send messages once WhatsApp is ready.

### Description
- Added `whatsapp-web.js` initialization using `LocalAuth` and a configurable Puppeteer option that reads `PUPPETEER_EXECUTABLE_PATH` if present. 
- Implemented QR-related endpoints `GET /whatsapp/qr` (base64), `GET /whatsapp/qr/image` (PNG), and `GET /whatsapp/qr-page` (HTML) plus `GET /whatsapp/status` and `POST /whatsapp/send`. 
- Added `formatWhatsappId` helper and logic to track QR data, generation time, and readiness state used by the endpoints. 
- Updated `package.json` to include `start` script and added `qrcode` and `whatsapp-web.js` to `dependencies`, and added a `README.md` with prerequisites and run instructions (including how to set `PUPPETEER_EXECUTABLE_PATH`).

### Testing
- No automated test suite was executed for this change. 
- An earlier attempt to install dependencies with `npm install` failed due to a blocked npm registry (`403 Forbidden`), so dependency install and runtime validation were not performed. 
- Files were inspected for syntax and endpoint wiring, but no runtime server start or integration tests were run in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f4cb277c83319441f980ebc7d296)